### PR TITLE
Fix: Resolve Blocking File Operations in `move_emojis_directory` and Code Improvements

### DIFF
--- a/custom_components/xplora_watch/__init__.py
+++ b/custom_components/xplora_watch/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     watches = await coordinator.controller.setDevices()
 
     await create_www_directory(hass)
-    move_emojis_directory(hass)
+    await move_emojis_directory(hass)
     await create_service_yaml_file(hass, entry, watches)
 
     # Create a copy and remove Platform.NOTIFY

--- a/custom_components/xplora_watch/entity.py
+++ b/custom_components/xplora_watch/entity.py
@@ -54,7 +54,6 @@ class XploraBaseEntity(CoordinatorEntity[XploraDataUpdateCoordinator], RestoreEn
             model=coordinator.data[self.watch_uid].get("model", DEVICE_NAME),
             name=f"{coordinator.username}{self.is_admin}{self.watch_name} ({self.watch_uid})",
             sw_version=coordinator.os_version,
-            # via_device=(DOMAIN, f"{self._config_entry.unique_id}_{coordinator.username}"),
             configuration_url="https://github.com/Ludy87/xplora_watch/blob/main/README.md",
         )
 

--- a/custom_components/xplora_watch/helper.py
+++ b/custom_components/xplora_watch/helper.py
@@ -101,14 +101,19 @@ async def create_www_directory(hass: HomeAssistant):
     await hass.async_add_executor_job(mkdir)
 
 
-def move_emojis_directory(hass: HomeAssistant):
+async def move_emojis_directory(hass: HomeAssistant):
     """Move emojis directory to www directory."""
     src_path = hass.config.path(f"{DATA_CUSTOM_COMPONENTS}/{DOMAIN}/emojis")
     dst_path = hass.config.path(f"www/{DOMAIN}")
-    if os.path.exists(src_path):
-        if os.path.exists(f"{dst_path}/emojis"):
-            shutil.rmtree(f"{dst_path}/emojis")
-        shutil.move(src_path, dst_path)
+
+    def move_directories():
+        if os.path.exists(src_path):
+            if os.path.exists(f"{dst_path}/emojis"):
+                shutil.rmtree(f"{dst_path}/emojis")
+            shutil.move(src_path, dst_path)
+
+    # Use executor to run blocking operations
+    await hass.async_add_executor_job(move_directories)
 
 
 async def load_yaml(fname: str | os.PathLike[str], secrets: Secrets | None = None) -> JSON_TYPE | None:

--- a/custom_components/xplora_watch/manifest.json
+++ b/custom_components/xplora_watch/manifest.json
@@ -20,5 +20,5 @@
     "marshmallow-enum",
     "security>=1.2"
   ],
-  "version": "v2.14.0"
+  "version": "v2.14.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,6 @@
     "zip_release": true,
     "render_readme": true,
     "homeassistant": "2025.1.0",
-    "hacs": "2.0.1",
+    "hacs": "2.0.2",
     "filename": "xplora_watch.zip"
 }


### PR DESCRIPTION
This pull request addresses an issue with blocking file operations (`os.scandir` in `shutil.rmtree`) inside the event loop and introduces several code optimizations for the `xplora_watch` integration.