### PR TITLE
v2.14.3

### DIFF
--- a/custom_components/xplora_watch/manifest.json
+++ b/custom_components/xplora_watch/manifest.json
@@ -13,12 +13,12 @@
     "pyxplora_api==2.12.9",
     "backoff>=2",
     "requests>=2",
-    "aiohttp>=3.11",
+    "aiohttp>=3.12",
     "geopy>=2.4",
     "dataclasses-json>=0.6",
     "pydub",
     "marshmallow-enum",
     "security>=1.2"
   ],
-  "version": "v2.14.2"
+  "version": "v2.14.3"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Xplora\u00ae Watch",
     "zip_release": true,
     "render_readme": true,
-    "homeassistant": "2025.1.0",
-    "hacs": "2.0.2",
+    "homeassistant": "2025.7.2",
+    "hacs": "2.0.5",
     "filename": "xplora_watch.zip"
 }


### PR DESCRIPTION
This pull request updates the dependencies and versioning for the `Xplora® Watch` integration, ensuring compatibility with newer versions of `aiohttp`, Home Assistant, and HACS.

Dependency updates:

* [`custom_components/xplora_watch/manifest.json`](diffhunk://#diff-6fdb0c82dbca94383111cf899935a334c4fee692de7daea7c6d7967b4131c643L16-R23): Updated the `aiohttp` dependency from version `>=3.11` to `>=3.12`.

Version updates:

* [`custom_components/xplora_watch/manifest.json`](diffhunk://#diff-6fdb0c82dbca94383111cf899935a334c4fee692de7daea7c6d7967b4131c643L16-R23): Incremented the integration version from `v2.14.2` to `v2.14.3`.
* [`hacs.json`](diffhunk://#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483fL5-R6): Updated the minimum required versions for Home Assistant (`2025.1.0` → `2025.7.2`) and HACS (`2.0.2` → `2.0.5`).